### PR TITLE
Wrapping iframe into a customisable div

### DIFF
--- a/includes/views/wp-vr-image-view-iframe.php
+++ b/includes/views/wp-vr-image-view-iframe.php
@@ -34,7 +34,7 @@
             }
 
 
-            $vrImageHtmlCode = ' <iframe width ="'.$width.'" height="'.$height.'" src="'.plugins_url().'/wp-vr-view/asset/index.html?image='.$imageUrl.$parameters.'"></iframe>';
+            $vrImageHtmlCode = '<div class="wp-vr-view"><iframe width ="'.$width.'" height="'.$height.'" src="'.plugins_url().'/wp-vr-view/asset/index.html?image='.$imageUrl.$parameters.'"></iframe></div>';
 
             return $vrImageHtmlCode;
         }

--- a/includes/views/wp-vr-video-view-iframe.php
+++ b/includes/views/wp-vr-video-view-iframe.php
@@ -31,7 +31,7 @@
             }
 
 
-            $vrVideoHtmlCode = ' <iframe width ="'.$width.'" height="'.$height.'" src="'.plugins_url().'/wp-vr-view/asset/index.html?video='.$videoUrl.$parameters.'"></iframe>';
+            $vrVideoHtmlCode = '<div class="wp-vr-view"><iframe width ="'.$width.'" height="'.$height.'" src="'.plugins_url().'/wp-vr-view/asset/index.html?video='.$videoUrl.$parameters.'"></iframe></div>';
 
             return $vrVideoHtmlCode;
         }


### PR DESCRIPTION
Hi there.

As per as the title, this wraps the image and video `<iframe>` into a `<div>` with the class `wp-vr-view`. It does not affect the css shipped with the plugin, however a user can now customise the display of the iframe (it was not particularly easy to target the `<iframe>` in CSS only)

I didn't put the class on the `<iframe>` directly because this HTML tag is a bit special: for instance, you cannot use pseudo CSS selectors `:before` or `:after`, hence the wrapping `<div>`